### PR TITLE
feat: prevent creation of virtual-private-gateway and use existing one

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ locals {
 resource "aws_vpn_connection" "default" {
   count = var.enable_vpn_connection && local.tunnel_details_not_specified ? 1 : 0
 
-  vpn_gateway_id                          = join("", aws_vpn_gateway.vpn[*].id)
+  vpn_gateway_id                          = var.virtual_private_gateway_id != null ? var.virtual_private_gateway_id : join("", aws_vpn_gateway.vpn[*].id)
   customer_gateway_id                     = join("", aws_customer_gateway.main[*].id)
   transit_gateway_id                      = var.transit_gateway_id
   type                                    = var.vpn_connection_type
@@ -106,9 +106,9 @@ resource "aws_vpn_connection" "default" {
 ## Provides a Virtual Private Gateway attachment resource, allowing for an existing hardware VPN gateway to be attached and/or detached from a VPC
 ##-----------------------------------------------------------------------------
 resource "aws_vpn_gateway_attachment" "default" {
-  count          = var.enable_vpn_connection && var.enable_vpn_gateway_attachment ? 1 : 0
+  count          = var.enable_vpn_connection && var.create_virtual_private_gateway && var.enable_vpn_gateway_attachment ? 1 : 0
   vpc_id         = var.vpc_id
-  vpn_gateway_id = join("", aws_vpn_gateway.vpn[*].id)
+  vpn_gateway_id = var.virtual_private_gateway_id != null ? var.virtual_private_gateway_id : join("", aws_vpn_gateway.vpn[*].id)
 }
 
 ##-----------------------------------------------------------------------------
@@ -150,7 +150,7 @@ resource "aws_customer_gateway" "main" {
 ## VPN gateways provide secure connectivity between multiple sites, such as on-premises data centers, Google Cloud Virtual Private Cloud (VPC) networks, and Google Cloud VMware Engine private clouds.
 ##-----------------------------------------------------------------------------
 resource "aws_vpn_gateway" "vpn" {
-  count           = var.enable_vpn_connection && var.enable_vpn_gateway_attachment ? 1 : 0
+  count           = var.enable_vpn_connection && var.enable_vpn_gateway_attachment && var.create_virtual_private_gateway ? 1 : 0
   vpc_id          = var.vpc_id
   amazon_side_asn = var.vpn_gateway_amazon_side_asn
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,9 +9,9 @@ output "vpn_connection_id" {
 }
 
 output "gateway_attachment_id" {
-  value = concat(
+  value = var.create_virtual_private_gateway ? concat(
     aws_vpn_gateway_attachment.default[*].id
-  )[0]
+  )[0] : "n/a"
   description = "The ID of the Gateway Attachment."
 }
 
@@ -23,9 +23,9 @@ output "customer_gateway_id" {
 }
 
 output "vpn_gateway_id" {
-  value = concat(
+  value = var.create_virtual_private_gateway ? concat(
     aws_vpn_gateway.vpn[*].id
-  )[0]
+  )[0] : var.create_virtual_private_gateway
   description = "The ID of the VPN gateway."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -84,6 +84,17 @@ variable "vpn_connection_static_routes_destinations" {
   description = "List of CIDRs to be used as destination for static routes (used with `vpn_connection_static_routes_only = true`). Routes to destinations set here will be propagated to the routing tables of the subnets defined in `vpc_subnet_route_table_ids`."
 }
 
+variable "virtual_private_gateway_id" {
+  type        = string
+  default     = null
+  description = "Provide id of existing Virtual Private Gateway"
+}
+
+variable "create_virtual_private_gateway" {
+  type        = bool
+  default     = true
+  description = "Set this to false to use existing Virtual Private Gateway(vgw) and prevent creation of vgw"
+}
 
 ###########################################################################################################################################
 ## tunnel 1


### PR DESCRIPTION
## what
- Feature to use existing Virtual Private Gateway

## why
- This module is creating Virtual-Private-Gateway by default
- Getting vgw-attachment error when creating two STS-VPN for same VPC as we can not attach to vgw to same VPC.